### PR TITLE
Feat/multi register support

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,18 @@ require("prompt-yank").setup({
 })
 ```
 
+### Register
+
+By default, yanked text is written to the `+` (system clipboard) register.
+You can set `register` to any single register or a list of registers:
+
+```lua
+require("prompt-yank").setup({
+  register = "+",            -- default: system clipboard
+  -- register = { "*", "+" }, -- write to both selection and clipboard registers
+})
+```
+
 ### Notes
 
 - No required dependencies (pure Lua).

--- a/lua/prompt-yank/yank.lua
+++ b/lua/prompt-yank/yank.lua
@@ -107,7 +107,13 @@ end
 function M.copy(text, opts)
   local conf = config.get()
   local register = (opts and opts.register) or conf.register
-  vim.fn.setreg(register, text, 'v')
+  if type(register) == 'table' then
+    for _, reg in ipairs(register) do
+      vim.fn.setreg(reg, text, 'v')
+    end
+  else
+    vim.fn.setreg(register, text, 'v')
+  end
   return text
 end
 

--- a/tests/prompt-yank/yank_spec.lua
+++ b/tests/prompt-yank/yank_spec.lua
@@ -1,5 +1,37 @@
 local yank = require('prompt-yank.yank')
 
+describe('prompt-yank.yank copy register', function()
+  local config = require('prompt-yank.config')
+
+  before_each(function() config.setup({ notify = false, register = '+' }) end)
+
+  it('copies to a single register string', function()
+    config.setup({ notify = false, register = '"' })
+    yank.copy('hello')
+    assert.equals('hello', vim.fn.getreg('"'))
+  end)
+
+  it('copies to multiple registers when register is a list', function()
+    config.setup({ notify = false, register = { '*', '+' } })
+    yank.copy('multi')
+    assert.equals('multi', vim.fn.getreg('*'))
+    assert.equals('multi', vim.fn.getreg('+'))
+  end)
+
+  it('opts.register list overrides config', function()
+    config.setup({ notify = false, register = '"' })
+    yank.copy('override', { register = { 'a', 'b' } })
+    assert.equals('override', vim.fn.getreg('a'))
+    assert.equals('override', vim.fn.getreg('b'))
+  end)
+
+  it('opts.register string overrides config', function()
+    config.setup({ notify = false, register = '"' })
+    yank.copy('single', { register = 'a' })
+    assert.equals('single', vim.fn.getreg('a'))
+  end)
+end)
+
 describe('prompt-yank.yank ctx placeholders', function()
   it('computes line placeholders for ranges', function()
     local ctx = yank.build_ctx_for_path('/tmp/a.lua', '/tmp', 'x', 'lua', 1, 3)

--- a/tests/prompt-yank/yank_spec.lua
+++ b/tests/prompt-yank/yank_spec.lua
@@ -3,7 +3,12 @@ local yank = require('prompt-yank.yank')
 describe('prompt-yank.yank copy register', function()
   local config = require('prompt-yank.config')
 
-  before_each(function() config.setup({ notify = false, register = '+' }) end)
+  before_each(function()
+    config.setup({ notify = false, register = '+' })
+    for _, r in ipairs({ '"', '*', '+', 'a', 'b' }) do
+      vim.fn.setreg(r, '')
+    end
+  end)
 
   it('copies to a single register string', function()
     config.setup({ notify = false, register = '"' })
@@ -12,10 +17,10 @@ describe('prompt-yank.yank copy register', function()
   end)
 
   it('copies to multiple registers when register is a list', function()
-    config.setup({ notify = false, register = { '*', '+' } })
+    config.setup({ notify = false, register = { 'a', 'b' } })
     yank.copy('multi')
-    assert.equals('multi', vim.fn.getreg('*'))
-    assert.equals('multi', vim.fn.getreg('+'))
+    assert.equals('multi', vim.fn.getreg('a'))
+    assert.equals('multi', vim.fn.getreg('b'))
   end)
 
   it('opts.register list overrides config', function()


### PR DESCRIPTION
Allow `register` config option to accept a list of registers in addition to a single string. When a list is provided, text is written to all specified registers.

    register = "+",            -- default: system clipboard
    register = { "*", "+" },   -- write to both selection and clipboard

Closes #7